### PR TITLE
Fixed some problems in wss-v2.c

### DIFF
--- a/wss-v2.c
+++ b/wss-v2.c
@@ -149,7 +149,7 @@ int mapidle(pid_t pid, unsigned long long mapstart, unsigned long long mapend)
 			err = 1;
 			goto out;
 		}
-		idlebits = g_idlebuf[idlemapp];
+		idlebits = g_idlebuf[idlemapp / 8];
 		if (g_debug > 1) {
 			printf("R: p %llx pfn %llx idlebits %llx\n",
 			    p[i], pfn, idlebits);

--- a/wss-v2.c
+++ b/wss-v2.c
@@ -245,7 +245,7 @@ int loadidlemap()
 	p = g_idlebuf;
 	// unfortunately, larger reads do not seem supported
 	while ((len = read(idlefd, p, IDLEMAP_CHUNK_SIZE)) > 0) {
-		p += IDLEMAP_CHUNK_SIZE;
+		p += 1;
 		g_idlebufsize += len;
 	}
 	close(idlefd);


### PR DESCRIPTION
1. The variable idlemapp means the size, if we want to get the index, we must divide eight, because the type of g_idlebuf is unsigned long long.
2. The type of variable p is unsigned long long, so we add one at a time in the loop.